### PR TITLE
Video Preview Time

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,23 @@ You can set options object for the preview generation. List of options available
 * width
 * height
 * quality [see quality documentation](https://www.imagemagick.org/script/command-line-options.php#quality)
+* previewTime
 
-e.g.
+e.g. Document/Image
 ```javascript
 var options = {
   width: 640,
   height: 480,
   quality: 90
+};
+
+e.g. Video
+```javascript
+var options = {
+  width: 640,
+  height: 480,
+  quality: 90,
+  previewTime: '00:03:00.000'
 };
 
 // Asynchronous

--- a/filepreview.js
+++ b/filepreview.js
@@ -80,10 +80,16 @@ module.exports = {
         return callback(true);
       } else {
         if ( fileType == 'video' ) {
-          var ffmpegArgs = ['-y', '-i', input, '-vf', 'thumbnail', '-frames:v', '1', output];
+          var ffmpegArgs = ['-y', '-i', input, '-vf', 'thumbnail', '-frames:v', '1'];
           if (options.width > 0 && options.height > 0) {
             ffmpegArgs.splice(4, 1, 'thumbnail,scale=' + options.width + ':' + options.height);
           }
+          if (options.hasOwnProperty('previewTime')) {
+            ffmpegArgs.push("-ss");
+            ffmpegArgs.push(options.previewTime)
+          }
+          ffmpegArgs.push(output);
+
           child_process.execFile('ffmpeg', ffmpegArgs, function(error) {
             if (input_original.indexOf("http://") == 0 || input_original.indexOf("https://") == 0) {
               fs.unlinkSync(input);


### PR DESCRIPTION
This node module originally only took the screenshot for the first few seconds of the video/movie. This is an issue because for most movies the first few seconds are black and the first few minutes are simple the introduction.

![beforefilepreview](https://user-images.githubusercontent.com/13894625/52526312-b675f600-2c84-11e9-8eda-1d3099d7b93e.png)

I updated the options configuration to have the option to specify when the preview is generated for videos. If the user passes in nothing for previewTime, this behaves as it did before. 

```
var options = {
    width: 200,
    quality: 50,
    previewTime: '00:10:30.000'
};
```

### Final results:

![afterfilepreview](https://user-images.githubusercontent.com/13894625/52526317-cd1c4d00-2c84-11e9-8a28-8e3693f3cd07.png)

@maxlabelle A review of this would be greatly appreciated. 

